### PR TITLE
Update DynamicDictionary.cs

### DIFF
--- a/src/DynamicDictionary/DynamicDictionary.cs
+++ b/src/DynamicDictionary/DynamicDictionary.cs
@@ -122,14 +122,7 @@ namespace DynamicDictionary
 
         public object this[ string key ]
         {
-            get
-            {
-                object value = null;
-
-                _dictionary.TryGetValue( key, out value );
-
-                return value;
-            }
+            get { return _dictionary[ key ]; }
             set { _dictionary[ key ] = value; }
         }
 
@@ -266,9 +259,14 @@ namespace DynamicDictionary
                 {
                     TValue value;
 
-                    _dictionary.TryGetValue( key, out value );
-
-                    return value;
+                    if ( _dictionary.TryGetValue( key, out value ) )
+                    {
+                        return value;
+                    }
+                    else
+                    {
+                        return default(TValue);
+                    }
                 }
                 set { _dictionary[ key ] = value; }
             }


### PR DESCRIPTION
In the index getter of DefaultDictionary, prefer to set a deterministic default value rather than rely on the framework Dictionary implementation of TryGetValue(). Further, since DynamicDictionary is choosing to use a DefaultDictionary as its composite dictionary, its own index getter no longer needs to TryGetValue(). It may simply return what the DefaultDictionary gives it.
